### PR TITLE
Add Prometheus metrics support

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from pika.exceptions import AMQPConnectionError, AMQPError
 
 from src.config import get_config
 from src.parsers import get_parser
+from src.metrics import start_metrics_server
 
 
 def setup_logging(level: str):
@@ -32,6 +33,9 @@ def main():
     # Setup logging from config
     setup_logging(cfg.logging.level)
     logging.info("Starting PlantedTrees Parser")
+
+    # Start Prometheus metrics server
+    start_metrics_server()
 
     # Instantiate parser based on type
     parser = get_parser(cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pika>=1.3.1           # RabbitMQ client
 python-dateutil~=2.9.0.post0
 kafka~=1.3.5
 pytest~=8.4.1
+prometheus-client>=0.17

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,22 @@
+from prometheus_client import Counter, Summary, start_http_server
+
+# Counters for message processing
+MESSAGES_IN = Counter(
+    'messages_in_total', 'Total number of messages received by the parser'
+)
+MESSAGES_OUT = Counter(
+    'messages_out_total', 'Total number of messages successfully processed'
+)
+MESSAGES_ERROR = Counter(
+    'messages_error_total', 'Total number of messages that resulted in an error'
+)
+
+# Summary to track parsing duration of each message
+PARSE_DURATION = Summary(
+    'message_parse_duration_seconds', 'Time spent parsing individual messages'
+)
+
+
+def start_metrics_server(port: int = 8000) -> None:
+    """Start the Prometheus metrics HTTP server."""
+    start_http_server(port)

--- a/src/parsers/json_parser.py
+++ b/src/parsers/json_parser.py
@@ -4,6 +4,12 @@ from src.config import ParserConfig
 from src.input_handler import get_input_handler
 from src.fields_parser import parse_line
 from src.output_handler import get_output_handler
+from src.metrics import (
+    MESSAGES_IN,
+    MESSAGES_OUT,
+    MESSAGES_ERROR,
+    PARSE_DURATION,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -31,15 +37,22 @@ class JSONParser:
         Args:
             raw (bytes): The raw message data to be processed.
         """
-        is_error = False
-        try:
-            record = parse_line(raw, self.cfg.parser, self.cfg.fields)
-            json_data = json.dumps(record, indent=4, sort_keys=True, default=str)
-            logger.debug("Parsed message: %s", json_data)
-            self.output_handler.publish(json_data)
-        except ValueError as e:
-            logger.error(f"Failed to parse message: {e}, sending to error output")
-            json_data = json.dumps({"raw_message": raw, "error": str(e)}, indent=4)
+        MESSAGES_IN.inc()
+        with PARSE_DURATION.time():
+            try:
+                record = parse_line(raw, self.cfg.parser, self.cfg.fields)
+                json_data = json.dumps(record, indent=4, sort_keys=True, default=str)
+                logger.debug("Parsed message: %s", json_data)
+                self.output_handler.publish(json_data)
+                MESSAGES_OUT.inc()
+            except ValueError as e:
+                logger.error(
+                    f"Failed to parse message: {e}, sending to error output"
+                )
+                json_data = json.dumps(
+                    {"raw_message": raw, "error": str(e)}, indent=4
+                )
+                MESSAGES_ERROR.inc()
 
     def run(self):
         """


### PR DESCRIPTION
## Summary
- add Prometheus metrics module and server startup
- track parsing metrics in `JSONParser`
- launch metrics server from entrypoint
- include prometheus client dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687135683c048325a713da73b7e4cbc0